### PR TITLE
started on google sign in functionality

### DIFF
--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -10,6 +10,9 @@ import AuthLoadingScreen from '../screens/AuthLoadingScreen';
 import RegisterScreen from '../screens/RegisterScreen';
 
 //put in the config stuff here
+
+//Dominique Settings
+/*
 const firebaseConfig = {
   apiKey: "AIzaSyBDgO4-__VMSSLUM_61o-f1evii7u-df9s",
   authDomain: "spark-charlie.firebaseapp.com",
@@ -20,6 +23,22 @@ const firebaseConfig = {
   appId: "1:293828812888:web:03565edf697b4695496a2d",
   measurementId: "G-ETD6MYYBKW"
 };
+*/
+
+//Rob Settings
+const firebaseConfig = {
+  apiKey: "AIzaSyClsa65AFI6N6usb5Oq_BS41RmHq4ICXQE",
+  authDomain: "aywspark.firebaseapp.com",
+  databaseURL: "https://aywspark.firebaseio.com",
+  projectId: "aywspark",
+  storageBucket: "aywspark.appspot.com",
+  messagingSenderId: "949736465328",
+  appId: "1:949736465328:web:3a0a2c76f73763b571ac75",
+  measurementId: "G-JLPJ32MJWJ"
+};
+
+
+
 // Initialize Firebase
 firebase.initializeApp(firebaseConfig);
 
@@ -40,6 +59,7 @@ export default createAppContainer(
     }
   )
 );
+
 
 // export default createAppContainer(
 //   createSwitchNavigator({

--- a/package-lock.json
+++ b/package-lock.json
@@ -5120,6 +5120,14 @@
         "uuid-js": "^0.7.5"
       }
     },
+    "expo-app-auth": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/expo-app-auth/-/expo-app-auth-7.0.0.tgz",
+      "integrity": "sha512-j5lSTm0uFcqSye8YJYB7bwBAS1VWYh1BcZc9NZPKn9hMz+RKdqJChB0Vx51mu07dDyD3eaV4U2Um7pKihAAatg==",
+      "requires": {
+        "invariant": "^2.2.4"
+      }
+    },
     "expo-app-loader-provider": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/expo-app-loader-provider/-/expo-app-loader-provider-7.0.0.tgz",
@@ -5162,6 +5170,23 @@
       "integrity": "sha512-OVlUydfexjq1u57Xlymcx5egfFF2WZ5MXkg3GGjHyiSMfp09inZ7OzAu+O/TXjxjlaq9d6vBXiwVxqQoUIlx1Q==",
       "requires": {
         "fontfaceobserver": "^2.1.0"
+      }
+    },
+    "expo-google-app-auth": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/expo-google-app-auth/-/expo-google-app-auth-7.0.0.tgz",
+      "integrity": "sha512-sVVl5yYrKD0FTGpvxCo4M1xCLgdDGtAYostsavzZjRAui0GpmA96iS7jMePltSWpffg4r7dIjRZEUbLjQ03g6g==",
+      "requires": {
+        "expo-app-auth": "~7.0.0",
+        "expo-constants": "~7.0.0"
+      }
+    },
+    "expo-google-sign-in": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/expo-google-sign-in/-/expo-google-sign-in-7.0.0.tgz",
+      "integrity": "sha512-amA2qUt75fSptFFycZJIvdQciOfgd1z3347vDee6JmRldLJq6BvaWoNf/394xyAW6JwQGxpWxhKiy0HQZvKGQQ==",
+      "requires": {
+        "invariant": "^2.2.4"
       }
     },
     "expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "expo": "^35.0.0",
     "expo-asset": "^7.0.0",
     "expo-constants": "^7.0.0",
+    "expo-facebook": "~7.0.0",
     "expo-font": "^7.0.0",
+    "expo-google-app-auth": "^7.0.0",
+    "expo-google-sign-in": "^7.0.0",
     "expo-web-browser": "^7.0.0",
     "firebase": "^7.5.0",
     "react": "16.8.3",
@@ -28,7 +31,7 @@
     "react-native-web": "^0.11.7",
     "react-navigation": "^3.12.0",
     "react-navigation-stack": "^1.10.3",
-    "expo-facebook": "~7.0.0"
+    "expo-app-auth": "~7.0.0"
   },
   "devDependencies": {
     "babel-preset-expo": "^7.0.0",

--- a/screens/AuthLoadingScreen.js
+++ b/screens/AuthLoadingScreen.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import  { View, Text, TextInput, StyleSheet } from 'react-native';
+import  { View, Text, TextInput, StyleSheet, ActivityIndicator } from 'react-native';
 import * as firebase from 'firebase';
 
 
@@ -16,6 +16,7 @@ export default class AuthLoadingScreen extends React.Component {
       <View style={styles.container}>
         <Text>Loading...</Text>
         <Text>The App will momentarially load.</Text>
+        <ActivityIndicator size='large' />
       </View>
     )
   }

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -2,8 +2,23 @@ import React from 'react';
 import  { View, Text, TextInput, StyleSheet, Button, TouchableOpacity, Alert } from 'react-native';
 import * as firebase from 'firebase';
 
-import * as Facebook from 'expo-facebook'
+import * as Facebook from 'expo-facebook';
 
+import * as Google from 'expo-google-app-auth';
+
+
+//ROB - RELATED TO CHANGE IN MODULES BELOW
+/*
+import { AppAuth } from 'expo-app-auth';
+
+// This value should contain your REVERSE_CLIENT_ID
+const { URLSchemes } = AppAuth;
+
+import * as GoogleSignIn from 'expo-google-sign-in';
+
+*/
+
+ 
 
 
 export default class LoginScreen extends React.Component {
@@ -11,7 +26,83 @@ export default class LoginScreen extends React.Component {
     email: '',
     password: '',
     errorMessage: null
+    //Rob - Change in modules code below
+    //user: null
   }
+
+
+  //ROB - RELATES TO CHANGE IN EXPO MODULES CODE BELOW
+  /*
+  componentDidMount() {
+    this.initAsync();
+  }
+
+
+
+  initAsync = async () => {
+    await GoogleSignIn.initAsync({
+     behavior: 'web',
+      clientId: '949736465328-87l4bcm3stjqdmn5e44qjkukrt1puc6c.apps.googleusercontent.com',
+    });
+    this._syncUserWithStateAsync();
+  };
+
+
+  _syncUserWithStateAsync = async () => {
+    const user = await GoogleSignIn.signInSilentlyAsync();
+    this.setState({ user });
+  };
+
+  signOutAsync = async () => {
+    await GoogleSignIn.signOutAsync();
+    this.setState({ user: null });
+  };
+
+  signInAsync = async () => {
+    try {
+      await GoogleSignIn.askForPlayServicesAsync();
+      const { type, user } = await GoogleSignIn.signInAsync();
+      if (type === 'success') {
+        this._syncUserWithStateAsync();
+      }
+    } catch ({ message }) {
+      alert('login: Error:' + message);
+    }
+  };
+
+  loginWithGoogle = () => {
+    if (this.state.user) {
+      this.signOutAsync();
+    } else {
+      this.signInAsync();
+    }
+  };
+
+*/
+
+//ROB NOTE - THE BELOW SIGN IN WORKS BETTER THAN THE CHANGES I TRIED TO MAKE TO GOOGLE LOGIN BUT IS DEPRECATED AND GIVES WARNINGS
+signInWithGoogleAsync = async () => {
+  try {
+    const result = await Google.logInAsync({
+      //androidClientId: YOUR_CLIENT_ID_HERE,
+      behavior: 'web',
+      iosClientId:
+      '949736465328-87l4bcm3stjqdmn5e44qjkukrt1puc6c.apps.googleusercontent.com'
+      ,
+      scopes: ['profile', 'email'],
+    });
+
+    if (result.type === 'success') {
+      return result.accessToken;
+    } else {
+      return { cancelled: true };
+    }
+  } catch (e) {
+    return { error: true };
+  }
+}
+
+
 
   handleLogin = () => {
     const { email, password } = this.state;
@@ -99,6 +190,13 @@ export default class LoginScreen extends React.Component {
                   style={{backgroundColor: 'blue', padding: 10}}>
                     <Text style={{color: 'white'}}> Login With Facebook </Text>
            </TouchableOpacity>
+
+           <TouchableOpacity
+                  onPress={()=> this.signInWithGoogleAsync()}
+                  style={{backgroundColor: 'white', padding: 10}}>
+                    <Text style={{color: 'blue'}}> Sign In With Google </Text>
+           </TouchableOpacity>
+
       </View>
 
 
@@ -107,6 +205,8 @@ export default class LoginScreen extends React.Component {
   }
 
 }
+
+
 
 const styles = StyleSheet.create({
   container:{

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -18,7 +18,7 @@ import * as GoogleSignIn from 'expo-google-sign-in';
 
 */
 
- 
+
 
 
 export default class LoginScreen extends React.Component {
@@ -42,7 +42,7 @@ export default class LoginScreen extends React.Component {
   initAsync = async () => {
     await GoogleSignIn.initAsync({
      behavior: 'web',
-      clientId: '949736465328-87l4bcm3stjqdmn5e44qjkukrt1puc6c.apps.googleusercontent.com',
+      clientId: 'SECRET',
     });
     this._syncUserWithStateAsync();
   };
@@ -87,7 +87,7 @@ signInWithGoogleAsync = async () => {
       //androidClientId: YOUR_CLIENT_ID_HERE,
       behavior: 'web',
       iosClientId:
-      '949736465328-87l4bcm3stjqdmn5e44qjkukrt1puc6c.apps.googleusercontent.com'
+      'SECRET'
       ,
       scopes: ['profile', 'email'],
     });


### PR DESCRIPTION
I've started on the Google sign in functionality. The expo modules and tutorials are out of date and I'm getting a warning saying it's deprecated. 

I tried to change to the new expo google sign in but couldn't get this to work. 

I'm pushing this code as it is working for google sign in and we can fix it up and refactor it afterwards. 

NOTE: I've connnected this to my firebase account @DominiqueBoyer we will discuss this on the next call as we can provide access to everyone to one firebase app so we don't have to change the settings or keys. 

This is being pushed with a different config file. I've left your config file in the same section but commented it out. You can change this if you need to test on your firebase account and going forward we'll all use the same app to avoid changing this. 